### PR TITLE
fix: 修复搜索时优先显示无数据而不是骨架屏并且页面抖动的问题 

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -529,7 +529,7 @@ const handleSingleSearch = async (item) => {
   };
 
   queue.push(task);
-  runQueue();
+  await runQueue();
 };
 
 const handleSearch = async () => {
@@ -544,9 +544,7 @@ const handleSearch = async () => {
     isLoading: true
   };
   
-  sourcesApiEndpoints.forEach(item => {
-    handleSingleSearch(item);
-  });
+  await Promise.all(sourcesApiEndpoints.map(item => handleSingleSearch(item) ));
 };
 
 // VOD搜索的单个处理函数
@@ -598,14 +596,15 @@ const searchByVod = async () => {
   });
 };
 
-const search = (e) => {
+const search = async (e) => {
+  skeletonLoading.value = true
   if (badWords.includes(e)) {
     return alert('请勿输入敏感词')
   }
   keyword.value = e
-  skeletonLoading.value = false
   sources.value = []
-  handleSearch()
+  await handleSearch()
+  skeletonLoading.value = false
 }
 
 const colorMode = useColorMode()

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -32,7 +32,7 @@
           <!-- Stats Display with Enhanced Visual -->
           <div v-if="category === 'clouddrive' && loadingProgress.isLoading"
             class="flex-1 flex items-center gap-4 bg-white/50 dark:bg-gray-700/50 rounded-lg p-3 transition-all duration-300 backdrop-blur-sm">
-            <div class="flex-1 relative">
+            <div class="flex-1 relative overflow-hidden">
               <el-progress
                 :percentage="Math.round((loadingProgress.completed / loadingProgress.total) * 100)"
                 :stroke-width="4"
@@ -517,6 +517,7 @@ const handleSingleSearch = async (item) => {
       if (res.list && res.list.length) {
         smartCache.set(cacheKey, res.list);
         sources.value.push(...res.list);
+        skeletonLoading.value = false
       }
     } catch (err) {
       console.error(`Error fetching from ${item.api}:`, err);
@@ -544,7 +545,7 @@ const handleSearch = async () => {
     isLoading: true
   };
   
-  await Promise.all(sourcesApiEndpoints.map(item => handleSingleSearch(item) ));
+  await Promise.all(sourcesApiEndpoints.map(item => handleSingleSearch(item)));
 };
 
 // VOD搜索的单个处理函数


### PR DESCRIPTION
骨架屏改为搜索时显示,当搜索结束或存在数据长度时关闭.